### PR TITLE
#12 switch to iptables-legacy

### DIFF
--- a/roles/os_base/tasks/main.yml
+++ b/roles/os_base/tasks/main.yml
@@ -20,3 +20,11 @@
     timezone:
       name: "{{ homek8s_os_base_timezone }}"
     when: homek8s_os_base_timezone is defined
+
+  - name: Switch iptables to iptables-legacy (needed for k3s)
+    alternatives:
+      name: "{{ item.name }}"
+      path: "{{ item.path }}"
+    with_items:
+      - { name: iptables, path: /usr/sbin/iptables-legacy }
+      - { name: ip6tables, path: /usr/sbin/ip6tables-legacy }


### PR DESCRIPTION
This PR switches all nodes (gateway, master, nodes) to iptables-legacy which is needed for k3s and fixes a problem with the gateway iptables rules.