### PR TITLE
#18 change dnsmasq to dynamic leases with infinite lease time

### DIFF
--- a/inventory/hosts.example
+++ b/inventory/hosts.example
@@ -60,14 +60,23 @@ homek8s_gateway_network_switch_interface_ip="192.168.2.1"
 #defaults to wlan0
 #homek8s_gateway_network_external_interface_name=wlan0
 
-#Specify the DHCP range from which IP addresses are given to
-#devices NOT listed in the nodes group
-#(so applies only to non-node devices plugged into the dedicated node switch)
-homek8s_gateway_network_dhcp_range_from=192.168.2.50
-homek8s_gateway_network_dhcp_range_to=192.168.2.100
+#Specify the DHCP range from which IP addresses are given to k8s nodes
+#range_prefix specifies the first three ip address segments of the dynamic dhcp range
+#MUST END WITH a dot (.)
+#(must match to homek8s_gateway_network_switch_interface_ip)
+#with the following default config k8s nodes will get ip addresses in the range 192.168.2.100 - 192.168.2.200
+homek8s_gateway_network_dhcp_range_prefix=192.168.2.
+#start number for the last ip address segment of the dhcp range
+homek8s_gateway_network_dhcp_range_from=100
+#last number for the last ip address segment of the dhcp range
+homek8s_gateway_network_dhcp_range_to=200
 
 #Specify the keyboard layout for all nodes
 #homek8s_os_base_xkblayout=de
 
 #Specify the timezone for all nodes
 #homek8s_os_base_timezone=Europe/Berlin
+
+#Enable / disable apt-get upgrade during node provisioning
+#defaults to true (upgrade performed)
+#homek8s_os_base_apt_upgrade=true

--- a/roles/gateway/defaults/main.yml
+++ b/roles/gateway/defaults/main.yml
@@ -1,8 +1,7 @@
 ---
-  homek8s_gateway_network_switch_interface_name: eth0
-  homek8s_gateway_network_external_interface_name: wlan0
-  #google dns as default upstream dns servers
-  homek8s_gateway_network_dns_upstream_servers:
-    - "8.8.8.8"
-    - "8.8.4.4"
-  homek8s_gateway_network_dhcp_lease_time: 12h
+homek8s_gateway_network_switch_interface_name: eth0
+homek8s_gateway_network_external_interface_name: wlan0
+#google dns as default upstream dns servers
+homek8s_gateway_network_dns_upstream_servers:
+  - "8.8.8.8"
+  - "8.8.4.4"

--- a/roles/gateway/tasks/main.yml
+++ b/roles/gateway/tasks/main.yml
@@ -1,81 +1,87 @@
 ---
-  - name: Install dnsmasq
-    apt:
-      name: dnsmasq
-    register: dnsmasq_install_result
+- name: Install dnsmasq
+  apt:
+    name: dnsmasq
+  register: dnsmasq_install_result
 
-  - name: Configure DHCPD config file
-    template:
-      src: dhcpcd.conf.j2
-      dest: /etc/dhcpcd.conf
-      owner: root
-      group: netdev
-      mode: u=rw,g=rw,o=r
-      backup: yes
-    notify:
-      - restart dhcpcd
+- name: Configure DHCPD config file
+  template:
+    src: dhcpcd.conf.j2
+    dest: /etc/dhcpcd.conf
+    owner: root
+    group: netdev
+    mode: u=rw,g=rw,o=r
+    backup: yes
+  notify:
+    - restart dhcpcd
 
-  - name: Configure dnsmasq config file
-    template:
-      src: dnsmasq.conf.j2
-      dest: /etc/dnsmasq.conf
-      owner: root
-      group: root
-      mode: u=rw,g=r,o=r
-      backup: yes
-    notify:
-      - restart dnsmasq
+- name: Configure dnsmasq config file
+  template:
+    src: dnsmasq.conf.j2
+    dest: /etc/dnsmasq.conf
+    owner: root
+    group: root
+    mode: u=rw,g=r,o=r
+    backup: yes
+  notify:
+    - restart dnsmasq
 
-# FIXME: add nodes to /etc/hosts
+- name: Pre-seed /etc/hosts file with all possible k8s node names
+  lineinfile:
+    path: /etc/hosts
+    line: "{{ homek8s_gateway_network_dhcp_range_prefix }}{{ item }} k8s-node-{{ item }}"
+  with_sequence: start={{ homek8s_gateway_network_dhcp_range_from }} end={{ homek8s_gateway_network_dhcp_range_to }}
+  notify:
+    - restart dnsmasq
 
-  - name: Allow ipv4 forwarding for nodes
-    sysctl:
-      name: net.ipv4.ip_forward
-      value: '1'
-      sysctl_set: yes
+- name: Allow ipv4 forwarding for nodes
+  sysctl:
+    name: net.ipv4.ip_forward
+    value: '1'
+    sysctl_set: yes
 
-  # Set iptables rules to forward nodes' traffic to external network
-  # see https://blog.sebastian-martens.de/2017/02/configure-raspberry-pi-as-wlan-to-ethernet-bridge/
+# Set iptables rules to forward nodes' traffic to external network
+# see https://blog.sebastian-martens.de/2017/02/configure-raspberry-pi-as-wlan-to-ethernet-bridge/
 
-  # raw rule: iptables -t nat -A POSTROUTING -o wlan0 -j MASQUERADE
-  - name: Add iptables rule for MASQUERADE over external interface
-    iptables:
-      table: nat
-      action: append
-      chain: POSTROUTING
-      out_interface: wlan0 # FIXME: make configurable
-      jump: MASQUERADE
-    notify:
-      - save iptables
+# raw rule: iptables -t nat -A POSTROUTING -o wlan0 -j MASQUERADE
+- name: Add iptables rule for MASQUERADE over external interface
+  iptables:
+    table: nat
+    action: append
+    chain: POSTROUTING
+    out_interface: "{{ homek8s_gateway_network_external_interface_name }}"
+    jump: MASQUERADE
+  notify:
+    - save iptables
 
-  # raw rule: iptables -A FORWARD -i wlan0 -o eth0 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-  # original rule documented in the link above uses "-m state --state RELATED,ESTABLISHED" instead of conntrack;
-  # if conntrack does not work, switch back to -m state.
-  # original rule on raspi pi: iptables -A FORWARD -i wlan0 -o eth0 -m state --state RELATED,ESTABLISHED -j ACCEPT
-  - name: Add iptables rule for accepting responses to forwarded connections
-    iptables:
-      action: append
-      chain: FORWARD
-      in_interface: "{{ homek8s_gateway_network_external_interface_name }}"
-      out_interface: "{{ homek8s_gateway_network_switch_interface_name }}"
-      ctstate: ESTABLISHED,RELATED
-      jump: ACCEPT
-    notify:
-      - save iptables
+# raw rule: iptables -A FORWARD -i wlan0 -o eth0 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+# original rule documented in the link above uses "-m state --state RELATED,ESTABLISHED" instead of conntrack;
+# if conntrack does not work, switch back to -m state.
+# original rule on raspi pi: iptables -A FORWARD -i wlan0 -o eth0 -m state --state RELATED,ESTABLISHED -j ACCEPT
+- name: Add iptables rule for accepting responses to forwarded connections
+  iptables:
+    action: append
+    chain: FORWARD
+    in_interface: "{{ homek8s_gateway_network_external_interface_name }}"
+    out_interface: "{{ homek8s_gateway_network_switch_interface_name }}"
+    ctstate: ESTABLISHED,RELATED
+    jump: ACCEPT
+  notify:
+    - save iptables
 
-  # raw rule: iptables -A FORWARD -i eth0 -o wlan0 -j ACCEPT
-  - name: Add iptables rule for forwarding traffic from dedicated switch interface to external interface
-    iptables:
-      action: append
-      chain: FORWARD
-      in_interface: "{{ homek8s_gateway_network_switch_interface_name }}"
-      out_interface: "{{ homek8s_gateway_network_external_interface_name }}"
-      jump: ACCEPT
-    notify:
-      - save iptables
+# raw rule: iptables -A FORWARD -i eth0 -o wlan0 -j ACCEPT
+- name: Add iptables rule for forwarding traffic from dedicated switch interface to external interface
+  iptables:
+    action: append
+    chain: FORWARD
+    in_interface: "{{ homek8s_gateway_network_switch_interface_name }}"
+    out_interface: "{{ homek8s_gateway_network_external_interface_name }}"
+    jump: ACCEPT
+  notify:
+    - save iptables
 
-  - name: Restore iptables rules during boot
-    lineinfile:
-      path: /etc/rc.local
-      line: iptables-restore < /etc/iptables.ipv4.nat
-      insertbefore: exit 0
+- name: Restore iptables rules during boot
+  lineinfile:
+    path: /etc/rc.local
+    line: iptables-restore < /etc/iptables.ipv4.nat
+    insertbefore: exit 0

--- a/roles/gateway/templates/dnsmasq.conf.j2
+++ b/roles/gateway/templates/dnsmasq.conf.j2
@@ -16,15 +16,6 @@ domain-needed # Don't forward short names
 # Never forward addresses in the non-routed address spaces.
 bogus-priv
 # Assign IP addresses between homek8s_gateway_network_dhcp_range_from
-# and homek8s_gateway_network_dhcp_range_from
-# with a homek8s_gateway_network_dhcp_lease_time hour lease time
-dhcp-range={{ homek8s_gateway_network_dhcp_range_from }},{{ homek8s_gateway_network_dhcp_range_to }},{{ homek8s_gateway_network_dhcp_lease_time }}
-
-# set static IPs for nodes
-# sample line: dhcp-host=x86-k8s-master-1,192.168.2.10
-{% for homek8s_host in groups['homek8s'] %}
-{% if homek8s_host not in groups['gateway'] %}
-dhcp-host={{ homek8s_host }},{{ hostvars[homek8s_host]['ansible_ssh_host'] }}
-{% endif %}
-{% endfor %}
-
+# and homek8s_gateway_network_dhcp_range_to
+# with an infinite lease time
+dhcp-range={{ homek8s_gateway_network_dhcp_range_prefix }}{{ homek8s_gateway_network_dhcp_range_from }},{{ homek8s_gateway_network_dhcp_range_prefix }}{{ homek8s_gateway_network_dhcp_range_to }},infinite

--- a/roles/os_base/tasks/main.yml
+++ b/roles/os_base/tasks/main.yml
@@ -1,30 +1,34 @@
 ---
-  - name: Update all installed packages
-    apt:
-      upgrade: yes
-      update_cache: yes
-  
-  - name: Install basic tools
-    apt:
-      name: [ 'tmux', 'vim' ]
+- name: apt-get update
+  apt:
+    update_cache: yes
 
-  - name: Set keyboard layout
-    lineinfile:
-      path: /etc/default/keyboard
-      regexp: '^XKBLAYOUT='
-      line: XKBLAYOUT="{{ homek8s_os_base_xkblayout }}"
-      backup: yes
-    when: homek8s_os_base_xkblayout is defined
+- name: Update all installed packages
+  apt:
+    upgrade: yes
+  when: homek8s_os_base_apt_upgrade | default(True) | bool
 
-  - name: Set timezone
-    timezone:
-      name: "{{ homek8s_os_base_timezone }}"
-    when: homek8s_os_base_timezone is defined
+- name: Install basic tools
+  apt:
+    name: [ 'tmux', 'vim' ]
 
-  - name: Switch iptables to iptables-legacy (needed for k3s)
-    alternatives:
-      name: "{{ item.name }}"
-      path: "{{ item.path }}"
-    with_items:
-      - { name: iptables, path: /usr/sbin/iptables-legacy }
-      - { name: ip6tables, path: /usr/sbin/ip6tables-legacy }
+- name: Set keyboard layout
+  lineinfile:
+    path: /etc/default/keyboard
+    regexp: '^XKBLAYOUT='
+    line: XKBLAYOUT="{{ homek8s_os_base_xkblayout }}"
+    backup: yes
+  when: homek8s_os_base_xkblayout is defined
+
+- name: Set timezone
+  timezone:
+    name: "{{ homek8s_os_base_timezone }}"
+  when: homek8s_os_base_timezone is defined
+
+- name: Switch iptables to iptables-legacy (needed for k3s)
+  alternatives:
+    name: "{{ item.name }}"
+    path: "{{ item.path }}"
+  with_items:
+    - { name: iptables, path: /usr/sbin/iptables-legacy }
+    - { name: ip6tables, path: /usr/sbin/ip6tables-legacy }

--- a/test/hosts.qemu
+++ b/test/hosts.qemu
@@ -40,8 +40,7 @@ ansible_become=yes
 #The following parameters assume that the dedicated network switch
 #covers the IP range 192.168.2.1 - 192.168.2.255 with
 # - the gateway being 192.168.2.1
-# - the nodes between 192.168.2.10 and 192.168.2.49
-# - dynamic IPs between 192.168.2.50 and 192.168.2.100
+# - the nodes between 192.168.2.100 and 192.168.2.200
 
 #Specify the gateway's network interface to the dedicated node switch
 #defaults to eth0
@@ -52,16 +51,25 @@ homek8s_gateway_network_switch_interface_ip="192.168.2.1"
 
 #Specify the gateway's network interface for external traffic (e.g. the wifi to your internet router)
 #defaults to wlan0
-#homek8s_gateway_network_external_interface_name=wlan0
+homek8s_gateway_network_external_interface_name=eth1
 
-#Specify the DHCP range from which IP addresses are given to
-#devices NOT listed in the nodes group
-#(so applies only to non-node devices plugged into the dedicated node switch)
-homek8s_gateway_network_dhcp_range_from=192.168.2.50
-homek8s_gateway_network_dhcp_range_to=192.168.2.100
+#Specify the DHCP range from which IP addresses are given to k8s nodes
+#range_prefix specifies the first three ip address segments of the dynamic dhcp range
+#MUST END WITH a dot (.)
+#(must match to homek8s_gateway_network_switch_interface_ip)
+#with the following default config k8s nodes will get ip addresses in the range 192.168.2.100 - 192.168.2.110
+homek8s_gateway_network_dhcp_range_prefix=192.168.2.
+#start number for the last ip address segment of the dhcp range
+homek8s_gateway_network_dhcp_range_from=100
+#last number for the last ip address segment of the dhcp range
+homek8s_gateway_network_dhcp_range_to=110
 
 #Specify the keyboard layout for all nodes
 #homek8s_os_base_xkblayout=de
 
 #Specify the timezone for all nodes
 #homek8s_os_base_timezone=Europe/Berlin
+
+#Enable / disable apt-get upgrade during node provisioning
+#defaults to true (upgrade performed)
+homek8s_os_base_apt_upgrade=false

--- a/test/native_run_homek8s.sh
+++ b/test/native_run_homek8s.sh
@@ -12,3 +12,5 @@ cd "$(dirname "$0")"
 # run default site.yml playbook to provision a homek8s cluster to the qemu VMs.
 # we use --network host so that the docker container can access the gateway VM's ssh port via localhost:5022
 docker run -it --rm --network host -v $(pwd)/hosts.qemu:/etc/ansible/hosts homek8s/homek8s
+
+cd "$OLD_PWD"

--- a/test/native_run_machines.sh
+++ b/test/native_run_machines.sh
@@ -11,7 +11,8 @@ qemu-system-arm \
   -M versatilepb \
   -cpu arm1176 \
   -m 256 \
-  -net nic -net user,hostfwd=tcp::5022-:22 \
+  -net nic,vlan=0 -net user,vlan=0,hostfwd=tcp::5022-:22 \
+  -net nic,vlan=1,model=virtio -net socket,vlan=1,mcast=230.0.0.1:1234 \
   -hda tmp/raspbian_lite_latest.img \
   -dtb tmp/qemu-rpi-kernel/versatile-pb.dtb \
   -kernel tmp/qemu-rpi-kernel/kernel-qemu-*-buster \
@@ -23,3 +24,5 @@ qemu-system-arm \
 # login in this console with user pi / password raspberry
 # or
 # login via "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 5022 pi@localhost"
+
+cd "$OLD_PWD"


### PR DESCRIPTION
dnsmasq now uses dhcp-range instead of dhcp-host for k8s nodes. I tested this locally with 2 QEMU VMs with raspbian - worked like a charm. The second VM could access the internet through the 1. VM (gateway); both VMs were running raspbian.